### PR TITLE
fix: preserve timestamp precision in stg_orders

### DIFF
--- a/models/staging/stg_orders.sql
+++ b/models/staging/stg_orders.sql
@@ -24,7 +24,7 @@ renamed as (
         {{ cents_to_dollars('order_total') }} as order_total,
 
         ---------- timestamps
-        {{ dbt.date_trunc('day','ordered_at') }} as ordered_at
+        ordered_at
 
     from source
 


### PR DESCRIPTION
## Summary
- Remove `date_trunc('day')` from `ordered_at` in `stg_orders` to preserve the full timestamp
- This column feeds **537 downstream models**; truncating to day broke all hourly/time-based analysis silently

## Changes
- `models/staging/stg_orders.sql`: Replace `{{ dbt.date_trunc('day','ordered_at') }}` with bare `ordered_at`

## Impact
- **1 model directly modified** (`state:modified`)
- **537 downstream models affected** (`1+state:modified+`)
- Hourly analysis models (`int_order_throughput_by_hour`, `int_peak_hour_analysis`, `geo_commute_pattern_proxy`, etc.) were silently producing zero-variance results

## Test plan
- [ ] Run `dbt build -s stg_orders+` and verify hourly models now show non-zero hours
- [ ] Verify `int_order_throughput_by_hour` produces distinct `order_hour` values
- [ ] Verify `int_peak_hour_analysis` shows meaningful peak/off-peak classification

## Size
+1/-1 across 1 file

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>