### PR TITLE
feat: add semantic equivalence test scenarios

### DIFF
--- a/models/intermediate/cross_domain/int_customer_rfm_scores.sql
+++ b/models/intermediate/cross_domain/int_customer_rfm_scores.sql
@@ -29,8 +29,8 @@ percentiles as (
     select
         customer_id,
         days_since_last_order,
-        order_count,
         total_spend,
+        order_count,
         ntile(5) over (order by days_since_last_order desc) as recency_score,
         ntile(5) over (order by order_count asc) as frequency_score,
         ntile(5) over (order by total_spend asc) as monetary_score
@@ -40,12 +40,12 @@ percentiles as (
 select
     customer_id,
     days_since_last_order,
-    order_count,
     total_spend,
+    order_count,
     recency_score,
     frequency_score,
     monetary_score,
-    recency_score + frequency_score + monetary_score as rfm_total_score,
+    monetary_score + frequency_score + recency_score as rfm_total_score,
     cast(recency_score as {{ dbt.type_string() }})
         || cast(frequency_score as {{ dbt.type_string() }})
         || cast(monetary_score as {{ dbt.type_string() }}) as rfm_segment_code

--- a/models/marts/customers.sql
+++ b/models/marts/customers.sql
@@ -1,34 +1,26 @@
+-- Customer dimension with lifetime order summary
 with
 
 customers as (
-
     select * from {{ ref('stg_customers') }}
-
 ),
 
 orders as (
-
     select * from {{ ref('orders') }}
-
 ),
 
 customer_orders_summary as (
-
     select
         orders.customer_id,
-
-        count(distinct orders.order_id) as count_lifetime_orders,
-        count(distinct orders.order_id) > 1 as is_repeat_buyer,
+        count(distinct orders.order_id) as count_lifetime_orders,  -- total unique orders
+        count(distinct orders.order_id) > 1 as is_repeat_buyer,    -- true if ordered more than once
         min(orders.ordered_at) as first_ordered_at,
         max(orders.ordered_at) as last_ordered_at,
         sum(orders.subtotal) as lifetime_spend_pretax,
         sum(orders.tax_paid) as lifetime_tax_paid,
-        sum(orders.order_total) as lifetime_spend
-
+        sum(orders.order_total) as lifetime_spend  -- includes tax
     from orders
-
     group by 1
-
 ),
 
 joined as (

--- a/models/marts/order_items.sql
+++ b/models/marts/order_items.sql
@@ -43,23 +43,23 @@ joined as (
     select
         order_items.*,
 
-        orders.ordered_at,
-
         products.product_name,
         products.product_price,
         products.is_food_item,
         products.is_drink_item,
 
+        orders.ordered_at,
+
         order_supplies_summary.supply_cost
 
     from order_items
 
-    left join orders on order_items.order_id = orders.order_id
+    left join products on products.product_id = order_items.product_id
 
-    left join products on order_items.product_id = products.product_id
+    left join orders on orders.order_id = order_items.order_id
 
     left join order_supplies_summary
-        on order_items.product_id = order_supplies_summary.product_id
+        on order_supplies_summary.product_id = order_items.product_id
 
 )
 

--- a/models/marts/products.sql
+++ b/models/marts/products.sql
@@ -6,4 +6,12 @@ products as (
 
 )
 
-select * from products
+select
+    product_price,
+    product_name,
+    is_drink_item,
+    product_id,
+    product_description,
+    is_food_item,
+    product_type
+from products

--- a/models/marts/scoring/scr_store_health.sql
+++ b/models/marts/scoring/scr_store_health.sql
@@ -83,23 +83,24 @@ scored as (
 
 ),
 
+-- Composite store health score and tiering
 final as (
 
     select
         location_id,
         store_name,
-        total_revenue,
         avg_operating_margin_pct,
+        total_revenue,
         avg_labor_cost_pct,
-        revenue_growth_score,
         profitability_score,
-        labor_efficiency_score,
+        revenue_growth_score,
         inventory_health_score,
-        revenue_growth_score + profitability_score + labor_efficiency_score + inventory_health_score as store_health_score,
+        labor_efficiency_score,
+        profitability_score + revenue_growth_score + inventory_health_score + labor_efficiency_score as store_health_score,
         case
-            when revenue_growth_score + profitability_score + labor_efficiency_score + inventory_health_score >= 75 then 'excellent'
-            when revenue_growth_score + profitability_score + labor_efficiency_score + inventory_health_score >= 50 then 'good'
-            when revenue_growth_score + profitability_score + labor_efficiency_score + inventory_health_score >= 25 then 'needs_improvement'
+            when profitability_score + revenue_growth_score + inventory_health_score + labor_efficiency_score >= 80 then 'excellent'
+            when profitability_score + revenue_growth_score + inventory_health_score + labor_efficiency_score >= 60 then 'good'
+            when profitability_score + revenue_growth_score + inventory_health_score + labor_efficiency_score >= 25 then 'needs_improvement'
             else 'critical'
         end as health_tier
 


### PR DESCRIPTION
## Summary

- Adds 5 semantic equivalence scenarios to exercise SQL equivalence detection in Recce
- **Reordered SELECT**: `products.sql` — explicit columns in different order than source
- **Commutative expressions**: `int_customer_rfm_scores.sql` — `a + b + c` → `c + b + a`
- **Reordered JOINs**: `order_items.sql` — JOIN clause order and condition sides swapped
- **Whitespace/comments only**: `customers.sql` — added comments, removed blank lines, zero logic change
- **Mixed (equivalence + breaking)**: `scr_store_health.sql` — column/addition reorder (equivalent) PLUS health_tier threshold change from 75→80 and 50→60 (breaking)

Resolves DRC-3189

## Test plan

- [ ] Run `dbt compile` to verify all models still compile
- [ ] Use Recce breaking change analysis to verify equivalence detection
- [ ] Confirm the mixed scenario correctly flags only the threshold change as breaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)