### PR TITLE
style: whitespace and comment-only edits in staging models

### DIFF
--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -1,23 +1,30 @@
 with
 
+
 source as (
+
 
     select * from {{ source('ecom', 'raw_customers') }}
 
+
 ),
+
 
 renamed as (
 
     select
 
-        ----------  ids
+        -- ================= identifiers =================
         cast(id as varchar) as customer_id,
 
-        ---------- text
+
+        -- ================= text fields =================
         name as customer_name
+
 
     from source
 
 )
+
 
 select * from renamed

--- a/models/staging/stg_locations.sql
+++ b/models/staging/stg_locations.sql
@@ -10,20 +10,20 @@ renamed as (
 
     select
 
-        ----------  ids
+        -- primary key: location identifier
         cast(id as varchar) as location_id,
 
-        ---------- text
+        -- display name for the location
         name as location_name,
 
-        ---------- numerics
+        -- tax rate applied at this location (percentage)
         tax_rate,
 
-        ---------- timestamps
+        -- opening date, truncated to day granularity
         {{ dbt.date_trunc('day', 'opened_at') }} as opened_date
 
     from source
 
 )
 
-select * from renamed
+SELECT * FROM renamed


### PR DESCRIPTION
## Summary

Pure formatting changes to two staging models — no semantic change.

- `stg_customers.sql`: add blank lines between CTEs / within SELECT; reformat section dividers from `---------- ids` style to `-- ================= identifiers =================` style.
- `stg_locations.sql`: replace terse column-group dividers with descriptive inline comments per column; uppercase final `SELECT * FROM renamed`.

Compiled SQL parses to an identical AST. Intended as an example PR for testing that Recce's change classifier treats AST-equal edits as unchanged rather than `non_breaking`.

## Test plan

- [ ] `dbt parse` succeeds
- [ ] `dbt compile --select stg_customers stg_locations` produces no row-level diff vs. base
- [ ] Recce lineage diff classifies both nodes as unchanged (not `non_breaking`)