### PR TITLE
chore(config): add deprecation date and tags to stg_customers

### DIFF
--- a/models/staging/stg_customers.yml
+++ b/models/staging/stg_customers.yml
@@ -1,6 +1,12 @@
 models:
   - name: stg_customers
-    description: Customer data with basic cleaning and transformation applied, one row per customer.
+    description: |
+      Customer data with basic cleaning and transformation applied, one row per customer.
+
+      Contains PII — downstream consumers must enforce access controls.
+    config:
+      tags: ["staging", "pii"]
+      deprecation_date: "2027-01-01"
     columns:
       - name: customer_id
         description: The unique key for each customer.


### PR DESCRIPTION
## Summary

YAML-only change to `stg_customers`:

- Add `config.tags: ["staging", "pii"]`
- Add `config.deprecation_date: "2027-01-01"`
- Extend description to flag PII concerns

The `.sql` file is unchanged, so compiled SQL is byte-identical between base and current. dbt's `state:modified` selector still fires (config changed), but Recce's classifier should recognize the node as semantically unchanged and drop it from the lineage diff. Intended as an example PR for exercising that path.

## Test plan

- [ ] `dbt parse` succeeds; `stg_customers` has expected tags and deprecation_date in the manifest
- [ ] `dbt compile --select stg_customers` produces byte-identical SQL vs. base
- [ ] `dbt ls --select state:modified --state <base>` includes `stg_customers`
- [ ] Recce lineage diff classifies `stg_customers` as unchanged