### PR TITLE
test(recce): cover lineage change categories

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,19 @@ Pre-built base artifacts (`manifest.json`, `catalog.json`) are included in `targ
 
 The answer key is available for validation.
 
+## Lineage Change-Category Fixture
+
+The `feature/drc-3552-change-category-visual-fixtures` branch is a visual-regression fixture for Recce Cloud's lineage graph. Comparing that branch with `main` produces one modified node in each change category:
+
+| Expected category | Node | Fixture change |
+|-------------------|------|----------------|
+| `breaking` | `narrow_active_employees` | Adds a row-level predicate |
+| `partial_breaking` | `narrow_order_date_range` | Renames an output column |
+| `non_breaking` | `narrow_avg_order_value` | Adds an output column |
+| `unknown` | `weekly_business_review` | Modifies an exposure, exercising the non-SQL classification path |
+
+Build `main` into the base target and the fixture branch into the current target before starting Recce. In `/info`, each node above should have the expected `change.category`; the same four categories should be present in `/cll` when change analysis is enabled.
+
 ## Project Structure
 
 ```

--- a/models/marts/_exposures.yml
+++ b/models/marts/_exposures.yml
@@ -6,7 +6,7 @@ exposures:
     type: dashboard
     maturity: high
     url: https://bi.jaffleshop.com/dashboards/weekly-review
-    description: Executive weekly business review dashboard showing KPIs, revenue trends, and store performance
+    description: Executive weekly business review dashboard showing KPIs, revenue trends, store performance, and category health
     depends_on:
       - ref('exec_company_kpis_monthly')
       - ref('rpt_store_pnl')

--- a/models/marts/narrow/narrow_active_employees.sql
+++ b/models/marts/narrow/narrow_active_employees.sql
@@ -1,3 +1,5 @@
 select count(*) as active_employee_count
 from {{ ref('dim_employees') }}
-where is_active = true
+where
+    is_active = true
+    and employee_id is not null

--- a/models/marts/narrow/narrow_avg_order_value.sql
+++ b/models/marts/narrow/narrow_avg_order_value.sql
@@ -1,1 +1,4 @@
-select avg(order_total) as avg_order_value from {{ ref('stg_orders') }}
+select
+    avg(order_total) as avg_order_value,
+    count(*) as order_count
+from {{ ref('stg_orders') }}

--- a/models/marts/narrow/narrow_order_date_range.sql
+++ b/models/marts/narrow/narrow_order_date_range.sql
@@ -1,4 +1,4 @@
 select
-    min(ordered_at) as min_date,
+    min(ordered_at) as first_order_date,
     max(ordered_at) as max_date
 from {{ ref('stg_orders') }}


### PR DESCRIPTION
## Summary

- Provides a dedicated visual-regression fixture for [recce-cloud-infra PR #1564](https://github.com/DataRecce/recce-cloud-infra/pull/1564).
- Produces exactly one modified dbt resource for each Recce lineage change category.
- Uses terminal models and an exposure so the fixture is focused and does not depend on malformed SQL or conditionally enabled seeds.
- Documents the expected node-to-category mapping in the README.

This PR is a test fixture and is not intended to merge. Keep it open while PR #1564 is under visual verification.

Supports DRC-3552.

## Expected categories

| Category | Resource |
|----------|----------|
| `breaking` | `narrow_active_employees` |
| `partial_breaking` | `narrow_order_date_range` |
| `non_breaking` | `narrow_avg_order_value` |
| `unknown` | `weekly_business_review` |

## Runtime prerequisites for PR #1564

Start the recce-cloud-infra backend with the legacy lineage UI selected:

```text
RECCE_DEFAULT_NEW_CLL_EXPERIENCE=false
RECCE_DEFAULT_WHOLE_MODEL_IMPACT=false
```

Then create or refresh a Recce Cloud session for this PR. Verify that `/info` and change-analysis `/cll` contain all four categories before capturing screenshots.

## Test plan

- [x] Full DuckDB dbt build: 1,918 passed, 0 errors
- [x] DuckDB docs/catalog generation passed
- [x] Snowflake target parsing passed (existing source-freshness deprecation warning only)
- [x] SQLFluff passed for all changed SQL models
- [x] `state:modified` reports exactly the four resources listed above
- [x] Recce 1.56 change-analysis `/api/cll` reports the expected category for all four resources
- [ ] Create or refresh the Recce Cloud preview session with both legacy-UI flags disabled
- [ ] Complete light- and dark-mode screenshots and post verification on PR #1564
